### PR TITLE
fix: resolve post page type errors and update Next.js config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,23 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['images.pexels.com'],
+    // Replace domains with remotePatterns
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.pexels.com',
+        pathname: '**',
+      },
+      // Add oliveuzoma.com if you're using images from there
+      {
+        protocol: 'https',
+        hostname: 'oliveuzoma.com',
+        pathname: '**',
+      },
+      // Add any other domains you need for images
+    ],
   },
   
-  // If you're using experimental features or other options, keep them here
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.5.0",
         "gray-matter": "^4.0.3",
-        "next": "15.1.6",
+        "next": "^15.1.7",
         "next-mdx-remote": "^5.0.0",
         "next-seo": "^6.6.0",
         "next-sitemap": "^4.2.3",
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.6.tgz",
-      "integrity": "sha512-d9AFQVPEYNr+aqokIiPLNK/MTyt3DWa/dpKveiAaVccUadFbhFEvY6FXYX2LJO2Hv7PHnLBu2oWwB4uBuHjr/w==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.7.tgz",
+      "integrity": "sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.6.tgz",
-      "integrity": "sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.7.tgz",
+      "integrity": "sha512-hPFwzPJDpA8FGj7IKV3Yf1web3oz2YsR8du4amKw8d+jAOHfYHYFpMkoF6vgSY4W6vB29RtZEklK9ayinGiCmQ==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.6.tgz",
-      "integrity": "sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.7.tgz",
+      "integrity": "sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==",
       "cpu": [
         "x64"
       ],
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.6.tgz",
-      "integrity": "sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.7.tgz",
+      "integrity": "sha512-sKLLwDX709mPdzxMnRIXLIT9zaX2w0GUlkLYQnKGoXeWUhcvpCrK+yevcwCJPdTdxZEUA0mOXGLdPsGkudGdnA==",
       "cpu": [
         "arm64"
       ],
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.6.tgz",
-      "integrity": "sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.7.tgz",
+      "integrity": "sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==",
       "cpu": [
         "arm64"
       ],
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.6.tgz",
-      "integrity": "sha512-SpuDEXixM3PycniL4iVCLyUyvcl6Lt0mtv3am08sucskpG0tYkW1KlRhTgj4LI5ehyxriVVcfdoxuuP8csi3kQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.7.tgz",
+      "integrity": "sha512-GOzXutxuLvLHFDAPsMP2zDBMl1vfUHHpdNpFGhxu90jEzH6nNIgmtw/s1MDwpTOiM+MT5V8+I1hmVFeAUhkbgQ==",
       "cpu": [
         "x64"
       ],
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.6.tgz",
-      "integrity": "sha512-L4druWmdFSZIIRhF+G60API5sFB7suTbDRhYWSjiw0RbE+15igQvE2g2+S973pMGvwN3guw7cJUjA/TmbPWTHQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.7.tgz",
+      "integrity": "sha512-WrZ7jBhR7ATW1z5iEQ0ZJfE2twCNSXbpCSaAunF3BKcVeHFADSI/AW1y5Xt3DzTqPF1FzQlwQTewqetAABhZRQ==",
       "cpu": [
         "x64"
       ],
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.6.tgz",
-      "integrity": "sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.7.tgz",
+      "integrity": "sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==",
       "cpu": [
         "arm64"
       ],
@@ -933,9 +933,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.6.tgz",
-      "integrity": "sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.7.tgz",
+      "integrity": "sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==",
       "cpu": [
         "x64"
       ],
@@ -5657,12 +5657,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.1.6.tgz",
-      "integrity": "sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.1.7.tgz",
+      "integrity": "sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.1.6",
+        "@next/env": "15.1.7",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -5677,14 +5677,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.1.6",
-        "@next/swc-darwin-x64": "15.1.6",
-        "@next/swc-linux-arm64-gnu": "15.1.6",
-        "@next/swc-linux-arm64-musl": "15.1.6",
-        "@next/swc-linux-x64-gnu": "15.1.6",
-        "@next/swc-linux-x64-musl": "15.1.6",
-        "@next/swc-win32-arm64-msvc": "15.1.6",
-        "@next/swc-win32-x64-msvc": "15.1.6",
+        "@next/swc-darwin-arm64": "15.1.7",
+        "@next/swc-darwin-x64": "15.1.7",
+        "@next/swc-linux-arm64-gnu": "15.1.7",
+        "@next/swc-linux-arm64-musl": "15.1.7",
+        "@next/swc-linux-x64-gnu": "15.1.7",
+        "@next/swc-linux-x64-musl": "15.1.7",
+        "@next/swc-win32-arm64-msvc": "15.1.7",
+        "@next/swc-win32-x64-msvc": "15.1.7",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "framer-motion": "^12.5.0",
     "gray-matter": "^4.0.3",
-    "next": "15.1.6",
+    "next": "^15.1.7",
     "next-mdx-remote": "^5.0.0",
     "next-seo": "^6.6.0",
     "next-sitemap": "^4.2.3",

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -4,161 +4,186 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import Image from "next/image";
 
-// Disable TypeScript checking for Next.js page props
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function generateMetadata(props: any): Promise<Metadata> {
-  const { slug } = props.params;
-  const post = await getPostBySlug(slug);
+// Updated type definition where both params and searchParams are Promise types
+type PageProps = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[]>>;
+};
 
-  if (!post) {
-    notFound();
-  }
-
-  return {
-    title: `${post.frontmatter?.title ?? "Untitled"} - Olive Uzoma`,
-    description: post.frontmatter?.excerpt ?? "",
-    openGraph: {
-      url: `https://oliveuzoma.com/${post.slug ?? ""}`,
-      title: post.frontmatter?.title ?? "Untitled",
-      description: post.frontmatter?.excerpt ?? "",
-      images: [
-        {
-          url: post.frontmatter?.featured_image ?? "",
-          width: 800,
-          height: 600,
-          alt: post.frontmatter?.title ?? "Blog Post Image",
-        },
-      ],
-      siteName: "Olive Uzoma",
-    },
-    twitter: {
-      creator: "@oliveuzoma",
-      card: "summary_large_image",
-      title: `${post.frontmatter?.title ?? "Untitled"} - Olive Uzoma`,
-      description: post.frontmatter?.excerpt ?? "",
-      images: {
-        url: post.frontmatter?.featured_image ?? "",
-        alt: post.frontmatter?.title ?? "Blog Post Image",
-      },
-    },
-  };
+// Helper function remains the same
+async function getSlugFromParams(params: Promise<{ slug: string }>): Promise<string> {
+  const resolvedParams = await params;
+  return resolvedParams.slug;
 }
 
-// Disable TypeScript checking for Next.js page props
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function PostPage(props: any) {
-  const { slug } = props.params;
-  const post = await getPostBySlug(slug);
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  try {
+    // Get slug safely
+    const slug = await getSlugFromParams(params);
+    
+    const post = await getPostBySlug(slug);
 
-  if (!post) {
-    notFound();
+    if (!post) {
+      notFound();
+    }
+
+    return {
+      title: `${post.frontmatter?.title ?? "Untitled"} - Olive Uzoma`,
+      description: post.frontmatter?.excerpt ?? "",
+      openGraph: {
+        url: `https://oliveuzoma.com/${post.slug ?? ""}`,
+        title: post.frontmatter?.title ?? "Untitled",
+        description: post.frontmatter?.excerpt ?? "",
+        images: [
+          {
+            url: post.frontmatter?.featured_image ?? "",
+            width: 800,
+            height: 600,
+            alt: post.frontmatter?.title ?? "Blog Post Image",
+          },
+        ],
+        siteName: "Olive Uzoma",
+      },
+      twitter: {
+        creator: "@oliveuzoma",
+        card: "summary_large_image",
+        title: `${post.frontmatter?.title ?? "Untitled"} - Olive Uzoma`,
+        description: post.frontmatter?.excerpt ?? "",
+        images: {
+          url: post.frontmatter?.featured_image ?? "",
+          alt: post.frontmatter?.title ?? "Blog Post Image",
+        },
+      },
+    };
+  } catch (error) {
+    console.error("Error generating metadata:", error);
+    return {
+      title: "Blog Post - Olive Uzoma",
+      description: "Read my latest blog post.",
+    };
   }
+}
 
-  // Handle reading time safely
-  const readingTimeDisplay = post.readingTime
-    ? typeof post.readingTime === "object"
-      ? post.readingTime.text || "1 min read"
-      : `${post.readingTime} min read`
-    : null;
+export default async function PostPage({ params }: PageProps) {
+  try {
+    // Get slug safely
+    const slug = await getSlugFromParams(params);
+    
+    const post = await getPostBySlug(slug);
 
-  return (
-    <div className="bg-white dark:bg-gray-900 min-h-screen">
-      {/* Enhanced Header with Text First, Image After */}
-      <header className="relative">
-        <div className="w-full bg-indigo-50 dark:bg-gray-900 pt-20 pb-10 px-[12rem] lg:px-[20rem]">
-          <div className="container mx-auto px-6 pt-12 text-left">
-            {/* First Tag (if available) */}
-            {post.frontmatter?.tags?.length > 0 && (
-              <span className="inline-block px-4 py-1 mb-6 bg-indigo-600/80 text-white rounded-full text-sm font-medium">
-                {post.frontmatter.tags[0]}
-              </span>
-            )}
+    if (!post) {
+      notFound();
+    }
 
-            {/* Title */}
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-indigo-900 dark:text-white mb-6 drop-shadow-md">
-              {post.frontmatter?.title ?? "Untitled"}
-            </h1>
+    // Handle reading time safely
+    const readingTimeDisplay = post.readingTime
+      ? typeof post.readingTime === "object"
+        ? post.readingTime.text || "1 min read"
+        : `${post.readingTime} min read`
+      : null;
 
-            {/* Excerpt/Summary */}
-            <p className="text-indigo-800/90 dark:text-white/90 text-lg md:text-xl mx-auto mb-8">
-              {post.frontmatter?.excerpt ?? ""}
-            </p>
+    return (
+      <div className="bg-white dark:bg-gray-900 min-h-screen">
+        {/* Enhanced Header with Text First, Image After */}
+        <header className="relative">
+          <div className="w-full bg-indigo-50 dark:bg-gray-900 pt-20 pb-10 px-[12rem] lg:px-[20rem]">
+            <div className="container mx-auto px-6 pt-12 text-left">
+              {/* First Tag (if available) */}
+              {post.frontmatter?.tags?.length > 0 && (
+                <span className="inline-block px-4 py-1 mb-6 bg-indigo-600/80 text-white rounded-full text-sm font-medium">
+                  {post.frontmatter.tags[0]}
+                </span>
+              )}
 
-            {/* Author, Date, Reading Time */}
-            <div className="flex text-indigo-700/90 dark:text-white/80 space-x-4 mb-16">
-              <div className="flex items-center">
-                <span className="text-sm">By {post.frontmatter?.author ?? "Unknown"}</span>
-              </div>
+              {/* Title */}
+              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-indigo-900 dark:text-white mb-6 drop-shadow-md">
+                {post.frontmatter?.title ?? "Untitled"}
+              </h1>
 
-              <div className="flex items-center">
-                <time dateTime={post.frontmatter?.date ?? ""} className="text-sm">
-                  {post.frontmatter?.date
-                    ? new Date(post.frontmatter.date).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })
-                    : "Unknown Date"}
-                </time>
-              </div>
+              {/* Excerpt/Summary */}
+              <p className="text-indigo-800/90 dark:text-white/90 text-lg md:text-xl mx-auto mb-8">
+                {post.frontmatter?.excerpt ?? ""}
+              </p>
 
-              {readingTimeDisplay && (
+              {/* Author, Date, Reading Time */}
+              <div className="flex text-indigo-700/90 dark:text-white/80 space-x-4 mb-16">
                 <div className="flex items-center">
-                  <span className="text-sm">{readingTimeDisplay}</span>
+                  <span className="text-sm">By {post.frontmatter?.author ?? "Unknown"}</span>
+                </div>
+
+                <div className="flex items-center">
+                  <time dateTime={post.frontmatter?.date ?? ""} className="text-sm">
+                    {post.frontmatter?.date
+                      ? new Date(post.frontmatter.date).toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })
+                      : "Unknown Date"}
+                  </time>
+                </div>
+
+                {readingTimeDisplay && (
+                  <div className="flex items-center">
+                    <span className="text-sm">{readingTimeDisplay}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Featured Image After Text */}
+              {post.frontmatter?.featured_image && (
+                <div className="w-full mx-auto h-[50vh] md:h-[60vh] relative rounded-lg overflow-hidden shadow-2xl">
+                  <Image
+                    src={post.frontmatter.featured_image}
+                    alt={post.frontmatter.title || "Featured image"}
+                    fill
+                    className="object-cover"
+                    priority
+                  />
                 </div>
               )}
             </div>
+          </div>
 
-            {/* Featured Image After Text */}
-            {post.frontmatter?.featured_image && (
-              <div className="w-full mx-auto h-[50vh] md:h-[60vh] relative rounded-lg overflow-hidden shadow-2xl">
-                <Image
-                  src={post.frontmatter.featured_image}
-                  alt={post.frontmatter.title || "Featured image"}
-                  fill
-                  className="object-cover"
-                  priority
-                />
+          {/* Decorative Wave Separator */}
+          <div className="w-full h-16 overflow-hidden">
+            <svg
+              preserveAspectRatio="none"
+              width="100%"
+              height="100%"
+              viewBox="0 0 1200 120"
+              xmlns="http://www.w3.org/2000/svg"
+              className="fill-white dark:fill-gray-900"
+            >
+              <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"></path>
+            </svg>
+          </div>
+        </header>
+
+        {/* Main Content */}
+        <main className="container mx-auto px-[17rem] py-8 -mt-6 relative">
+          <article className="prose dark:prose-invert lg:prose-lg max-w-none bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 md:p-10 text-gray-800 dark:text-gray-200 leading-[2.625]">
+            <MDXRemote source={post.content ?? ""} components={{}} />
+          </article>
+
+          {/* Tags Section */}
+          {post.frontmatter?.tags?.length > 0 && (
+            <div className="mt-12 pt-6 border-t border-gray-200 dark:border-gray-700">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Tags</h3>
+              <div className="flex flex-wrap gap-2">
+                {post.frontmatter.tags.map((tag: string) => (
+                  <span key={tag} className="px-3 py-1 bg-indigo-50 dark:bg-gray-800 text-indigo-700 dark:text-white rounded-full text-sm">
+                    {tag}
+                  </span>
+                ))}
               </div>
-            )}
-          </div>
-        </div>
-
-        {/* Decorative Wave Separator */}
-        <div className="w-full h-16 overflow-hidden">
-          <svg
-            preserveAspectRatio="none"
-            width="100%"
-            height="100%"
-            viewBox="0 0 1200 120"
-            xmlns="http://www.w3.org/2000/svg"
-            className="fill-white dark:fill-gray-900"
-          >
-            <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"></path>
-          </svg>
-        </div>
-      </header>
-
-      {/* Main Content */}
-      <main className="container mx-auto px-[17rem] py-8 -mt-6 relative">
-        <article className="prose dark:prose-invert lg:prose-lg max-w-none bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 md:p-10 text-gray-800 dark:text-gray-200 leading-[2.625]">
-          <MDXRemote source={post.content ?? ""} components={{}} />
-        </article>
-
-        {/* Tags Section */}
-        {post.frontmatter?.tags?.length > 0 && (
-          <div className="mt-12 pt-6 border-t border-gray-200 dark:border-gray-700">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Tags</h3>
-            <div className="flex flex-wrap gap-2">
-              {post.frontmatter.tags.map((tag: string) => (
-                <span key={tag} className="px-3 py-1 bg-indigo-50 dark:bg-gray-800 text-indigo-700 dark:text-white rounded-full text-sm">
-                  {tag}
-                </span>
-              ))}
             </div>
-          </div>
-        )}
-      </main>
-    </div>
-  );
+          )}
+        </main>
+      </div>
+    );
+  } catch (error) {
+    console.error("Error rendering post:", error);
+    notFound();
+  }
 }

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,29 +1,10 @@
 "use client";
-
-import Link from "next/link";
-import { useTheme } from "./ThemeProvider";
+import Navbar from './Navbar';
 
 export default function Header() {
-  const { theme } = useTheme();
-  
   return (
-    <header className={`shadow-sm ${theme === 'dark' ? 'bg-gray-900 text-white' : 'bg-white text-gray-900'}`}>
-      <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-        <div className="flex items-center">
-          <Link href="/" className="text-xl font-bold">
-            Olive Uzoma
-          </Link>
-        </div>
-        
-        <nav className="hidden md:flex space-x-6">
-          <Link href="/" className="hover:text-indigo-600 dark:hover:text-indigo-400">
-            Home
-          </Link>
-          <Link href="/blog" className="hover:text-indigo-600 dark:hover:text-indigo-400">
-            Blog
-          </Link>
-        </nav>
-      </div>
-    </header>
+    <>
+      <Navbar />
+    </>
   );
 }


### PR DESCRIPTION
fix: resolve post page type errors and update Next.js config

Bundles several updates including fixing type errors on the post page,
updating Next.js configuration and dependencies, and reverting header changes.

- Implemented type handling in `[slug]/page.tsx` using Promises for props
  and a helper function to resolve the slug, addressing previous build errors.
  Added try/catch blocks for robustness. [fix(blog)]
- Updated `next.config.ts` to use `images.remotePatterns` instead of the
  deprecated `images.domains`, adding patterns for pexels.com and
  oliveuzoma.com. [fix(config)]
- Bumped Next.js dependency from 15.1.6 to 15.1.7. [chore(deps)]
- Reverted changes in `Header.tsx`, restoring the use of the separate
  `Navbar` component. [revert]